### PR TITLE
Tiny whitespace fix for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm install -s num-client
 ## Importing the Client
 Use this import to make the client available for use:
 ```Typescript
-import { 
+import {
   createClient,     // required for creating the `NUMClient`
   createDnsClient,  // optional unless you need to override the default DoH endpoint
   parseNumUri,      // required for converting the NUM URI string into a valid `NumUri` object


### PR DESCRIPTION
A very minor one, but when copy pasting the code example here my editor highlighted a stray space, so thought I'd mention it. Feel free to ignore or do as you see fit.